### PR TITLE
BUG: Missing package init

### DIFF
--- a/q2_diversity_lib/tests/__init__.py
+++ b/q2_diversity_lib/tests/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2018-2019, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
This missing package init is preventing the tests from being packaged in conda:

https://busywork.qiime2.org/teams/main/pipelines/master-distribution/jobs/unit-test-q2-diversity-lib/builds/2

You can see in the link above that the test runner collects zero tests (because there are none, in the built conda package).