### PR TITLE
BUG: Multiple values for 'n_jobs' or 'threads'

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -39,4 +39,4 @@ jobs:
     - uses: qiime2/action-library-packaging@alpha1
       with: 
         plugin-name: q2-diversity-lib
-        additional-tests: pytest --pyargs q2_diversity_lib
+        additional-tests: pytest --pyargs q2_diversity_lib --capture=tee-sys

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -83,14 +83,21 @@ def _validate_requested_cpus(wrapped_function, *args, **kwargs):
     cpus_requested = b_a_arguments[param_name]
 
     if cpus_requested == 'auto':
-        # mutate bound_arguments.arguments 'auto' to the requested # of cpus
+        # mutate bound_arguments.arguments 'auto' to the requested # of cpus...
         b_a_arguments[param_name] = cpus_available
-        return wrapped_function(*bound_arguments.args,
-                                **bound_arguments.kwargs)
+        # ...and update cpus requested to prevent TypeError
+        cpus_requested = cpus_available
 
     if cpus_requested > cpus_available:
         raise ValueError(f"The value passed to '{param_name}' cannot exceed "
                          f"the number of processors ({cpus_available}) "
                          "available to the system.")
 
+    # TODO: remove print statements
+    print("param_name: ", param_name)
+    print("n_jobs_or_threads in bound_arguments.args: ",
+          b_a_arguments[param_name])
+    print("b_a_arguments: ", b_a_arguments)
+    print("args passed to call: ", *bound_arguments.args)
+    print("kwargs passed to call: ", **bound_arguments.kwargs)
     return wrapped_function(*bound_arguments.args, **bound_arguments.kwargs)

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -91,12 +91,9 @@ def _validate_requested_cpus(wrapped_function, *args, **kwargs):
                          "available to the system.")
 
     if cpus_requested == 'auto':
-        # remove 'auto' from args to prevent 'multiple values' TypeError...
-        argslist = list(args)
-        argslist.remove('auto')
-        return_args = tuple(argslist)
-        # ...then inject number of available cpus
-        return wrapped_function(*return_args, **{param_name: cpus_available},
-                                **kwargs)
+        # replace 'auto' with the requested number of cpus and return
+        b_a_arguments[param_name] = cpus_available
+        return wrapped_function(*bound_arguments.args,
+                                **bound_arguments.kwargs)
 
     return wrapped_function(*args, **kwargs)

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -57,22 +57,22 @@ def _disallow_empty_tables(wrapped_function, *args, **kwargs):
 def _validate_requested_cpus(wrapped_function, *args, **kwargs):
     bound_arguments = signature(wrapped_function).bind(*args, **kwargs)
     bound_arguments.apply_defaults()
+    b_a_arguments = bound_arguments.arguments
 
     # Handle duplicate param names
-    if all(params in bound_arguments.arguments
-            for params in ['n_jobs', 'threads']):
+    if 'n_jobs' in b_a_arguments and 'threads' in b_a_arguments:
         raise TypeError("Duplicate parameters: The _validate_requested_cpus "
                         "decorator may not be applied to callables with both "
                         "'n_jobs' and 'threads' parameters. Do you really need"
                         " both?")
 
     # Handle cpu requests coming from different parameter names
-    if 'n_jobs' in bound_arguments.arguments:
+    if 'n_jobs' in b_a_arguments:
         param_name = 'n_jobs'
-        cpus_requested = bound_arguments.arguments[param_name]
-    elif 'threads' in bound_arguments.arguments:
+        cpus_requested = b_a_arguments[param_name]
+    elif 'threads' in b_a_arguments:
         param_name = 'threads'
-        cpus_requested = bound_arguments.arguments[param_name]
+        cpus_requested = b_a_arguments[param_name]
     else:
         raise TypeError("The _validate_requested_cpus decorator may not be"
                         " applied to callables without an 'n_jobs' or "

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -93,11 +93,4 @@ def _validate_requested_cpus(wrapped_function, *args, **kwargs):
                          f"the number of processors ({cpus_available}) "
                          "available to the system.")
 
-    # TODO: remove print statements
-    print("param_name: ", param_name)
-    print("n_jobs_or_threads in bound_arguments.args: ",
-          b_a_arguments[param_name])
-    print("b_a_arguments: ", b_a_arguments)
-    print("args passed to call: ", *bound_arguments.args)
-    print("kwargs passed to call: ", **bound_arguments.kwargs)
     return wrapped_function(*bound_arguments.args, **bound_arguments.kwargs)

--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -55,8 +55,6 @@ def unweighted_unifrac(table: BIOMV210Format,
                        phylogeny: NewickFormat,
                        threads: int = 1,
                        bypass_tips: bool = False) -> skbio.DistanceMatrix:
-    # TODO: remove print statement
-    print("threads passed to unifrac: ", threads)
     return unifrac.unweighted(str(table), str(phylogeny), threads=threads,
                               variance_adjusted=False, bypass_tips=bypass_tips)
 

--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -55,6 +55,8 @@ def unweighted_unifrac(table: BIOMV210Format,
                        phylogeny: NewickFormat,
                        threads: int = 1,
                        bypass_tips: bool = False) -> skbio.DistanceMatrix:
+    # TODO: remove print statement
+    print("threads passed to unifrac: ", threads)
     return unifrac.unweighted(str(table), str(phylogeny), threads=threads,
                               variance_adjusted=False, bypass_tips=bypass_tips)
 

--- a/q2_diversity_lib/tests/test_beta.py
+++ b/q2_diversity_lib/tests/test_beta.py
@@ -5,11 +5,13 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import unittest.mock as mock
 
 import numpy as np
 import numpy.testing as npt
 import biom
 import skbio
+import psutil
 
 from qiime2.plugin.testing import TestPluginBase
 from q2_types.feature_table import BIOMV210Format
@@ -238,9 +240,16 @@ class UnweightedUnifrac(TestPluginBase):
         p_a_table_fp = self.get_data_path('two_feature_p_a_table.biom')
         self.p_a_table_as_BIOMV210Format = BIOMV210Format(p_a_table_fp,
                                                           mode='r')
+        self.table_as_artifact = Artifact.import_data(
+                    'FeatureTable[Frequency]', self.table_as_BIOMV210Format)
 
         tree_fp = self.get_data_path('three_feature.tree')
         self.tree_as_NewickFormat = NewickFormat(tree_fp, mode='r')
+        self.tree_as_artifact = Artifact.import_data(
+                    'Phylogeny[Rooted]', self.tree_as_NewickFormat)
+
+        self.unweighted_unifrac_thru_framework = self.plugin.actions[
+                    'unweighted_unifrac']
 
     def test_method(self):
         actual = unweighted_unifrac(self.table_as_BIOMV210Format,
@@ -266,14 +275,21 @@ class UnweightedUnifrac(TestPluginBase):
                                             self.expected[id1, id2])
 
     def test_does_it_run_through_framework(self):
-        unweighted_unifrac_thru_framework = self.plugin.actions[
-                    'unweighted_unifrac']
-        table_as_artifact = Artifact.import_data(
-                    'FeatureTable[Frequency]', self.table_as_BIOMV210Format)
-        tree_as_artifact = Artifact.import_data(
-                    'Phylogeny[Rooted]', self.tree_as_NewickFormat)
-        unweighted_unifrac_thru_framework(table_as_artifact,
-                                          tree_as_artifact)
+        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
+                                               self.tree_as_artifact)
+        # If we get here, then it ran without error
+        self.assertTrue(True)
+
+    @mock.patch("q2_diversity_lib._util.psutil.Process")
+    def test_cpu_request_through_framework(self, mock_process):
+        mock_process = psutil.Process()
+        mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2])
+        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
+                                               self.tree_as_artifact,
+                                               threads=2)
+        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
+                                               self.tree_as_artifact,
+                                               threads='auto')
         # If we get here, then it ran without error
         self.assertTrue(True)
 

--- a/q2_diversity_lib/tests/test_beta.py
+++ b/q2_diversity_lib/tests/test_beta.py
@@ -280,19 +280,6 @@ class UnweightedUnifrac(TestPluginBase):
         # If we get here, then it ran without error
         self.assertTrue(True)
 
-    @mock.patch("q2_diversity_lib._util.psutil.Process")
-    def test_cpu_request_through_framework(self, mock_process):
-        mock_process = psutil.Process()
-        mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2])
-        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
-                                               self.tree_as_artifact,
-                                               threads=2)
-        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
-                                               self.tree_as_artifact,
-                                               threads='auto')
-        # If we get here, then it ran without error
-        self.assertTrue(True)
-
 
 class WeightedUnifrac(TestPluginBase):
     package = 'q2_diversity_lib.tests'

--- a/q2_diversity_lib/tests/test_beta.py
+++ b/q2_diversity_lib/tests/test_beta.py
@@ -5,13 +5,10 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-import unittest.mock as mock
-
 import numpy as np
 import numpy.testing as npt
 import biom
 import skbio
-import psutil
 
 from qiime2.plugin.testing import TestPluginBase
 from q2_types.feature_table import BIOMV210Format

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 import unittest.mock as mock
-from unittest.mock import MagicMock
 
 import numpy as np
 import biom
@@ -125,7 +124,7 @@ class ValidateRequestedCPUsTests(TestPluginBase):
     @mock.patch('psutil.cpu_count', return_value=999)
     def test_system_has_no_cpu_affinity(self, mock_cpu_count, mock_process):
         mock_process = psutil.Process()
-        mock_process.cpu_affinity = MagicMock(side_effect=AttributeError)
+        mock_process.cpu_affinity = mock.MagicMock(side_effect=AttributeError)
         self.assertEqual(self.function_w_n_jobs_param(999), 999)
         assert mock_process.cpu_affinity.called
 

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,19 +175,19 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-    def test_cpu_request_through_framework(self):
-        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
-        self.jaccard_thru_framework(self.larger_table_as_artifact,
-                                    n_jobs='auto')
-        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-                                               self.larger_tree_as_artifact,
-                                               threads=1)
-        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-                                               self.larger_tree_as_artifact,
-                                               threads='auto')
-        # If we get here, then it ran without error
-        self.assertTrue(True)
-
+#     def test_cpu_request_through_framework(self):
+#         self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
+#         self.jaccard_thru_framework(self.larger_table_as_artifact,
+#                                     n_jobs='auto')
+#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+#                                                self.larger_tree_as_artifact,
+#                                                threads=1)
+#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+#                                                self.larger_tree_as_artifact,
+#                                                threads='auto')
+#         # If we get here, then it ran without error
+#         self.assertTrue(True)
+#
 #     def test_more_threads_than_max_stripes(self):
 #         # The two_feature_table used here has only three samples, meaning
 #         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -203,11 +203,11 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.unweighted_unifrac_thru_framework(
                 self.two_feature_table_as_artifact,
                 self.valid_tree_as_artifact, threads=1)
-        self.unweighted_unifrac_thru_framework(
-                self.two_feature_table_as_artifact,
-                self.valid_tree_as_artifact, threads=3)
-        self.unweighted_unifrac_thru_framework(
-                self.two_feature_table_as_artifact,
-                self.valid_tree_as_artifact, threads='auto')
+        # self.unweighted_unifrac_thru_framework(
+        #         self.two_feature_table_as_artifact,
+        #         self.valid_tree_as_artifact, threads=3)
+        # self.unweighted_unifrac_thru_framework(
+        #         self.two_feature_table_as_artifact,
+        #         self.valid_tree_as_artifact, threads='auto')
         # If we get here, then it ran without error
         self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -193,7 +193,10 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertTrue(True)
 
     @mock.patch("q2_diversity_lib._util.psutil.Process")
-    def test_more_threads_than_features_in_table(self, mock_process):
+    def test_more_threads_than_max_stripes(self, mock_process):
+        # The two_feature_table used here has only three samples, meaning
+        # that it has a max of (3+1)/2 = 2 stripes. Calls for more than two
+        # stripes should produce an error from unifrac
         mock_process = psutil.Process()
         mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2, 4])
         self.unweighted_unifrac_thru_framework(

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,29 +175,29 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-#     def test_cpu_request_through_framework(self):
-#         self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
-#         self.jaccard_thru_framework(self.larger_table_as_artifact,
-#                                     n_jobs='auto')
-#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-#                                                self.larger_tree_as_artifact,
-#                                                threads=1)
-#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-#                                                self.larger_tree_as_artifact,
-#                                                threads='auto')
-#         # If we get here, then it ran without error
-#         self.assertTrue(True)
-#
-#     def test_more_threads_than_max_stripes(self):
-#         # The two_feature_table used here has only three samples, meaning
-#         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
-#         # requests of more-threads-than-stripes to stderror, but should handl
-#         # that situation gracefully.
-#         self.unweighted_unifrac_thru_framework(
-#                 self.two_feature_table_as_artifact,
-#                 self.valid_tree_as_artifact, threads=1)
-#         self.unweighted_unifrac_thru_framework(
-#                 self.two_feature_table_as_artifact,
-#                 self.valid_tree_as_artifact, threads='auto')
-#         # If we get here, then it ran without error
-#         self.assertTrue(True)
+    def test_cpu_request_through_framework(self):
+        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
+        self.jaccard_thru_framework(self.larger_table_as_artifact,
+                                    n_jobs='auto')
+        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+                                               self.larger_tree_as_artifact,
+                                               threads=1)
+        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+                                               self.larger_tree_as_artifact,
+                                               threads='auto')
+        # If we get here, then it ran without error
+        self.assertTrue(True)
+
+    def test_more_threads_than_max_stripes(self):
+        # The two_feature_table used here has only three samples, meaning
+        # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
+        # requests of more-threads-than-stripes to stderror, but should handle
+        # that situation gracefully.
+        self.unweighted_unifrac_thru_framework(
+                self.two_feature_table_as_artifact,
+                self.valid_tree_as_artifact, threads=1)
+        self.unweighted_unifrac_thru_framework(
+                self.two_feature_table_as_artifact,
+                self.valid_tree_as_artifact, threads='auto')
+        # If we get here, then it ran without error
+        self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,39 +175,29 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-    @mock.patch("q2_diversity_lib._util.psutil.Process")
-    def test_cpu_request_through_framework(self, mock_process):
-        mock_process = psutil.Process()
-        mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2])
-
-        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=2)
+    def test_cpu_request_through_framework(self):
+        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
         self.jaccard_thru_framework(self.larger_table_as_artifact,
                                     n_jobs='auto')
         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
                                                self.larger_tree_as_artifact,
-                                               threads=2)
+                                               threads=1)
         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
                                                self.larger_tree_as_artifact,
                                                threads='auto')
         # If we get here, then it ran without error
         self.assertTrue(True)
 
-    @mock.patch("q2_diversity_lib._util.psutil.Process")
-    def test_more_threads_than_max_stripes(self, mock_process):
+    def test_more_threads_than_max_stripes(self):
         # The two_feature_table used here has only three samples, meaning
         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
         # requests of more-threads-than-stripes to stderror, but should handle
         # that situation gracefully.
-        mock_process = psutil.Process()
-        mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2, 4])
         self.unweighted_unifrac_thru_framework(
                 self.two_feature_table_as_artifact,
                 self.valid_tree_as_artifact, threads=1)
-        # self.unweighted_unifrac_thru_framework(
-        #         self.two_feature_table_as_artifact,
-        #         self.valid_tree_as_artifact, threads=3)
-        # self.unweighted_unifrac_thru_framework(
-        #         self.two_feature_table_as_artifact,
-        #         self.valid_tree_as_artifact, threads='auto')
+        self.unweighted_unifrac_thru_framework(
+                self.two_feature_table_as_artifact,
+                self.valid_tree_as_artifact, threads='auto')
         # If we get here, then it ran without error
         self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -195,8 +195,9 @@ class ValidateRequestedCPUsTests(TestPluginBase):
     @mock.patch("q2_diversity_lib._util.psutil.Process")
     def test_more_threads_than_max_stripes(self, mock_process):
         # The two_feature_table used here has only three samples, meaning
-        # that it has a max of (3+1)/2 = 2 stripes. Calls for more than two
-        # stripes should produce an error from unifrac
+        # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
+        # requests of more-threads-than-stripes to stderror, but should handle
+        # that situation gracefully.
         mock_process = psutil.Process()
         mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2, 4])
         self.unweighted_unifrac_thru_framework(
@@ -209,5 +210,4 @@ class ValidateRequestedCPUsTests(TestPluginBase):
                 self.two_feature_table_as_artifact,
                 self.valid_tree_as_artifact, threads='auto')
         # If we get here, then it ran without error
-        # TODO: revert to assertTrue(True)
-        self.assertTrue(False)
+        self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,29 +175,29 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-    def test_cpu_request_through_framework(self):
-        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
-        self.jaccard_thru_framework(self.larger_table_as_artifact,
-                                    n_jobs='auto')
-        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-                                               self.larger_tree_as_artifact,
-                                               threads=1)
-        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-                                               self.larger_tree_as_artifact,
-                                               threads='auto')
-        # If we get here, then it ran without error
-        self.assertTrue(True)
-
-    def test_more_threads_than_max_stripes(self):
-        # The two_feature_table used here has only three samples, meaning
-        # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
-        # requests of more-threads-than-stripes to stderror, but should handle
-        # that situation gracefully.
-        self.unweighted_unifrac_thru_framework(
-                self.two_feature_table_as_artifact,
-                self.valid_tree_as_artifact, threads=1)
-        self.unweighted_unifrac_thru_framework(
-                self.two_feature_table_as_artifact,
-                self.valid_tree_as_artifact, threads='auto')
-        # If we get here, then it ran without error
-        self.assertTrue(True)
+#     def test_cpu_request_through_framework(self):
+#         self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
+#         self.jaccard_thru_framework(self.larger_table_as_artifact,
+#                                     n_jobs='auto')
+#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+#                                                self.larger_tree_as_artifact,
+#                                                threads=1)
+#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+#                                                self.larger_tree_as_artifact,
+#                                                threads='auto')
+#         # If we get here, then it ran without error
+#         self.assertTrue(True)
+#
+#     def test_more_threads_than_max_stripes(self):
+#         # The two_feature_table used here has only three samples, meaning
+#         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
+#         # requests of more-threads-than-stripes to stderror, but should handl
+#         # that situation gracefully.
+#         self.unweighted_unifrac_thru_framework(
+#                 self.two_feature_table_as_artifact,
+#                 self.valid_tree_as_artifact, threads=1)
+#         self.unweighted_unifrac_thru_framework(
+#                 self.two_feature_table_as_artifact,
+#                 self.valid_tree_as_artifact, threads='auto')
+#         # If we get here, then it ran without error
+#         self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -173,18 +173,15 @@ class ValidateRequestedCPUsTests(TestPluginBase):
 
         mock_process = psutil.Process()
         mock_process.cpu_affinity = mock.MagicMock(return_value=[0, 1, 2])
-        # TODO: uncomment these test cases once bug fixed.
-        # self.unweighted_unifrac_thru_framework(self.table_as_artifact,
-        #                                        self.tree_as_artifact,
-        #                                        threads=2)
+        self.unweighted_unifrac_thru_framework(self.table_as_artifact,
+                                               self.tree_as_artifact,
+                                               threads=2)
         self.unweighted_unifrac_thru_framework(self.table_as_artifact,
                                                self.tree_as_artifact,
                                                threads='auto')
         self.jaccard_thru_framework(self.table_as_artifact,
-                                    self.tree_as_artifact,
                                     n_jobs=2)
-        # self.jaccard_thru_framework(self.table_as_artifact,
-        #                             self.tree_as_artifact,
-        #                             n_jobs='auto')
+        self.jaccard_thru_framework(self.table_as_artifact,
+                                    n_jobs='auto')
         # If we get here, then it ran without error
         self.assertTrue(True)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,7 +175,11 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-    def test_cpu_request_through_framework(self):
+    @mock.patch("q2_diversity_lib._util.psutil.Process")
+    def test_cpu_request_through_framework(self, mock_process):
+        mock_process = psutil.Process()
+        mock_process.cpu_affinity = mock.MagicMock(return_value=[0])
+
         self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
         self.jaccard_thru_framework(self.larger_table_as_artifact,
                                     n_jobs='auto')
@@ -188,7 +192,11 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         # If we get here, then it ran without error
         self.assertTrue(True)
 
-    def test_more_threads_than_max_stripes(self):
+    @mock.patch("q2_diversity_lib._util.psutil.Process")
+    def test_more_threads_than_max_stripes(self, mock_process):
+        mock_process = psutil.Process()
+        mock_process.cpu_affinity = mock.MagicMock(return_value=[0])
+
         # The two_feature_table used here has only three samples, meaning
         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report
         # requests of more-threads-than-stripes to stderror, but should handle

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -175,19 +175,19 @@ class ValidateRequestedCPUsTests(TestPluginBase):
         self.assertEqual(self.function_w_threads_param('auto'), 3)
         self.assertEqual(self.function_w_threads_param(threads='auto'), 3)
 
-#     def test_cpu_request_through_framework(self):
-#         self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
-#         self.jaccard_thru_framework(self.larger_table_as_artifact,
-#                                     n_jobs='auto')
-#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-#                                                self.larger_tree_as_artifact,
-#                                                threads=1)
-#         self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
-#                                                self.larger_tree_as_artifact,
-#                                                threads='auto')
-#         # If we get here, then it ran without error
-#         self.assertTrue(True)
-#
+    def test_cpu_request_through_framework(self):
+        self.jaccard_thru_framework(self.larger_table_as_artifact, n_jobs=1)
+        self.jaccard_thru_framework(self.larger_table_as_artifact,
+                                    n_jobs='auto')
+        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+                                               self.larger_tree_as_artifact,
+                                               threads=1)
+        self.unweighted_unifrac_thru_framework(self.larger_table_as_artifact,
+                                               self.larger_tree_as_artifact,
+                                               threads='auto')
+        # If we get here, then it ran without error
+        self.assertTrue(True)
+
 #     def test_more_threads_than_max_stripes(self):
 #         # The two_feature_table used here has only three samples, meaning
 #         # that it has a max of (3+1)/2 = 2 stripes. Unifrac may report


### PR DESCRIPTION
Attempts to diagnose and fix a bug initially discovered [here](https://github.com/qiime2/q2-diversity-lib/pull/6#issuecomment-642338410), in which beta diversity `n_Jobs` and `threads` parameters are being passed multiple values when called through the framework with 'auto'. 