### PR TITLE
Exposing unifrac.meta

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - q2-types {{ release }}.*
     - scikit-bio
     - scipy
-    - unifrac
+    - unifrac >=0.20.0
 
 test:
   imports:

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -34,17 +34,21 @@ def _disallow_empty_tables(wrapped_function, *args, **kwargs):
     if table is None:
         raise TypeError("The wrapped function has no parameter 'table'")
 
-    if isinstance(table, BIOMV210Format):
-        table = str(table)
-        table_obj = biom.load_table(table)
-    elif isinstance(table, biom.Table):
-        table_obj = table
-    else:
-        raise ValueError("Invalid view type: table passed as "
-                         f"{type(table)}")
+    if not isinstance(table, (tuple, list, set)):
+        table = [table]
 
-    if table_obj.is_empty():
-        raise ValueError("The provided table is empty")
+    for tab in table:
+        if isinstance(tab, BIOMV210Format):
+            tab = str(tab)
+            tab_obj = biom.load_table(tab)
+        elif isinstance(tab, biom.Table):
+            tab_obj = tab
+        else:
+            raise ValueError("Invalid view type: table passed as "
+                             f"{type(tab)}")
+
+        if tab_obj.is_empty():
+            raise ValueError("The provided table is empty")
 
     return wrapped_function(*args, **kwargs)
 

--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -117,6 +117,7 @@ def beta_phylogenetic_passthrough(table: BIOMV210Format,
                 variance_adjusted=variance_adjusted, bypass_tips=bypass_tips)
 
 
+@_disallow_empty_tables
 @_validate_requested_cpus
 def beta_phylogenetic_meta_passthrough(table: BIOMV210Format,
                                        phylogeny: NewickFormat,

--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -124,7 +124,9 @@ def beta_phylogenetic_meta_passthrough(table: BIOMV210Format,
                                        threads: int = 1,
                                        variance_adjusted: bool = False,
                                        alpha: float = None,
-                                       bypass_tips: bool = False
+                                       bypass_tips: bool = False,
+                                       weights: list = None,
+                                       consolidation: str='skipping_missing_values'  # noqa
                                        ) -> skbio.DistanceMatrix:
     # Ideally we remove this when we can support optional type-mapped params.
     if alpha is not None and metric != 'generalized_unifrac':
@@ -139,8 +141,8 @@ def beta_phylogenetic_meta_passthrough(table: BIOMV210Format,
 
     return unifrac.meta(tuple([str(t) for t in table]),
                         tuple([str(p) for p in phylogeny]),
-                        weights=None, threads=threads,
-                        consolidation=None, method=metric,
+                        weights=weights, threads=threads,
+                        consolidation=consolidation, method=metric,
                         variance_adjusted=variance_adjusted,
                         alpha=alpha, bypass_tips=bypass_tips)
 

--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -117,6 +117,34 @@ def beta_phylogenetic_passthrough(table: BIOMV210Format,
                 variance_adjusted=variance_adjusted, bypass_tips=bypass_tips)
 
 
+@_validate_requested_cpus
+def beta_phylogenetic_meta_passthrough(table: BIOMV210Format,
+                                       phylogeny: NewickFormat,
+                                       metric: str,
+                                       threads: int = 1,
+                                       variance_adjusted: bool = False,
+                                       alpha: float = None,
+                                       bypass_tips: bool = False
+                                       ) -> skbio.DistanceMatrix:
+    # Ideally we remove this when we can support optional type-mapped params.
+    if alpha is not None and metric != 'generalized_unifrac':
+        raise ValueError("The alpha parameter is only allowed when the "
+                         "selected metric is 'generalized_unifrac'")
+
+    metric_map = {'unweighted_unifrac': 'unweighted',
+                  'weighted_normalized_unifrac': 'weighted_normalized',
+                  'weighted_unifrac': 'weighted_unnormalized',
+                  'generalized_unifrac': 'generalized'}
+    metric = metric_map[metric]
+
+    return unifrac.meta(tuple([str(t) for t in table]),
+                        tuple([str(p) for p in phylogeny]),
+                        weights=None, threads=threads,
+                        consolidation=None, method=metric,
+                        variance_adjusted=variance_adjusted,
+                        alpha=alpha, bypass_tips=bypass_tips)
+
+
 # --------------------Non-Phylogenetic-----------------------
 @_disallow_empty_tables
 @_validate_requested_cpus

--- a/q2_diversity_lib/citations.bib
+++ b/q2_diversity_lib/citations.bib
@@ -1,3 +1,19 @@
+@article{lozupone2008metaunifrac,
+	author = {Lozupone, Catherine A. and Hamady, Micah and Cantarel, Brandi L. and Coutinho, Pedro M. and Henrissat, Bernard and Gordon, Jeffrey I. and Knight, Rob},
+	title = {The convergence of carbohydrate active gene repertoires in human gut microbes},
+	volume = {105},
+	number = {39},
+	pages = {15076--15081},
+	year = {2008},
+	doi = {10.1073/pnas.0807339105},
+	publisher = {National Academy of Sciences},
+	abstract = {The extreme variation in gene content among phylogenetically related microorganisms suggests that gene acquisition, expansion, and loss are important evolutionary forces for adaptation to new environments. Accordingly, phylogenetically disparate organisms that share a habitat may converge in gene content as they adapt to confront shared challenges. This response should be especially pronounced for functional genes that are important for survival in a particular habitat. We illustrate this principle by showing that the repertoires of two different types of carbohydrate-active enzymes, glycoside hydrolases and glycosyltransferases, have converged in bacteria and archaea that live in the human gut and that this convergence is largely due to horizontal gene transfer rather than gene family expansion. We also identify gut microbes that may have more similar dietary niches in the human gut than would be expected based on phylogeny. The techniques used to obtain these results should be broadly applicable to understanding the functional genes and evolutionary processes important for adaptation in many environments and useful for interpreting the large number of reference microbial genome sequences being generated for the International Human Microbiome Project.},
+	issn = {0027-8424},
+	URL = {https://www.pnas.org/content/105/39/15076},
+	eprint = {https://www.pnas.org/content/105/39/15076.full.pdf},
+	journal = {Proceedings of the National Academy of Sciences}
+}
+
 @article{faith1992conservation,
   title = {Conservation evaluation and phylogenetic diversity},
   author = {Faith, Daniel P},

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (Plugin, Citations, Bool, Int, Range, Choices, Str,
-                           Float)
+                           Float, List)
 from q2_types.feature_table import (FeatureTable, Frequency, RelativeFrequency,
                                     PresenceAbsence)
 from q2_types.tree import Phylogeny, Rooted
@@ -335,6 +335,61 @@ plugin.methods.register_function(
     },
     output_descriptions={'distance_matrix': 'The resulting distance matrix.'},
     name='Beta Phylogenetic Passthrough',
+    description="Computes a distance matrix for all pairs of samples in a "
+                "feature table using the unifrac implementation of the "
+                "selected beta diversity metric.",
+    citations=[
+        citations['lozupone2005unifrac'],
+        citations['lozupone2007unifrac'],
+        citations['hamady2010unifrac'],
+        citations['lozupone2011unifrac'],
+        citations['mcdonald2018unifrac'],
+        citations['chang2011variance'],
+        citations['chen2012genUnifrac']
+    ]
+)
+
+
+plugin.methods.register_function(
+    function=beta.beta_phylogenetic_meta_passthrough,
+    inputs={'table': List[FeatureTable[Frequency]],
+            'phylogeny': List[Phylogeny[Rooted]]},
+    parameters={'metric': Str % Choices(beta.METRICS['PHYLO']['UNIMPL']),
+                'threads': Int % Range(1, None) | Str % Choices(['auto']),
+                'variance_adjusted': Bool,
+                'alpha': Float % Range(0, 1, inclusive_end=True),
+                'bypass_tips': Bool},
+    outputs=[('distance_matrix', DistanceMatrix)],
+    input_descriptions={
+        'table': 'The feature tables containing the samples over which beta '
+                 'diversity should be computed.',
+        'phylogeny': 'Phylogenetic trees containing tip identifiers that '
+                     'correspond to the feature identifiers in the table. '
+                     'This tree can contain tip ids that are not present in '
+                     'the table, but all feature ids in the table must be '
+                     'present in this tree.'
+    },
+    parameter_descriptions={
+        'metric': 'The beta diversity metric to be computed.',
+        'threads': threads_description,
+        'variance_adjusted': 'Perform variance adjustment based on Chang et '
+                             'al. BMC Bioinformatics 2011. Weights distances '
+                             'based on the proportion of the relative '
+                             'abundance represented between the samples at a'
+                             ' given node under evaluation.',
+        'alpha': 'This parameter is only used when the choice of metric is '
+                 'generalized_unifrac. The value of alpha controls importance'
+                 ' of sample proportions. 1.0 is weighted normalized UniFrac.'
+                 ' 0.0 is close to unweighted UniFrac, but only if the sample'
+                 ' proportions are dichotomized.',
+        'bypass_tips': 'In a bifurcating tree, the tips make up about 50% of '
+                       'the nodes in a tree. By ignoring them, specificity '
+                       'can be traded for reduced compute time. This has the '
+                       'effect of collapsing the phylogeny, and is analogous '
+                       '(in concept) to moving from 99% to 97% OTUs'
+    },
+    output_descriptions={'distance_matrix': 'The resulting distance matrix.'},
+    name='Beta Phylogenetic Meta Passthrough',
     description="Computes a distance matrix for all pairs of samples in a "
                 "feature table using the unifrac implementation of the "
                 "selected beta diversity metric.",

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -13,6 +13,7 @@ from q2_types.feature_table import (FeatureTable, Frequency, RelativeFrequency,
 from q2_types.tree import Phylogeny, Rooted
 from q2_types.sample_data import AlphaDiversity, SampleData
 from q2_types.distance_matrix import DistanceMatrix
+from unifrac._meta import CONSOLIDATIONS
 
 from . import alpha, beta, __version__
 
@@ -358,7 +359,9 @@ plugin.methods.register_function(
                 'threads': Int % Range(1, None) | Str % Choices(['auto']),
                 'variance_adjusted': Bool,
                 'alpha': Float % Range(0, 1, inclusive_end=True),
-                'bypass_tips': Bool},
+                'bypass_tips': Bool,
+                'weights': List[Float],
+                'consolidation': Str % Choices(list(CONSOLIDATIONS))},
     outputs=[('distance_matrix', DistanceMatrix)],
     input_descriptions={
         'table': 'The feature tables containing the samples over which beta '
@@ -386,7 +389,13 @@ plugin.methods.register_function(
                        'the nodes in a tree. By ignoring them, specificity '
                        'can be traded for reduced compute time. This has the '
                        'effect of collapsing the phylogeny, and is analogous '
-                       '(in concept) to moving from 99% to 97% OTUs'
+                       '(in concept) to moving from 99% to 97% OTUs',
+        'weights': 'The weight applied to each tree/table pair. This tuple is '
+                   'expected to be in index order with tables and phylogenies.'
+                   ' Default is to weight each tree/table pair evenly.',
+        'consolidation': 'The matrix consolidation method, which determines '
+                         'how the individual distance matrices are '
+                         'aggregated'
     },
     output_descriptions={'distance_matrix': 'The resulting distance matrix.'},
     name='Beta Phylogenetic Meta Passthrough',

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -390,9 +390,9 @@ plugin.methods.register_function(
     },
     output_descriptions={'distance_matrix': 'The resulting distance matrix.'},
     name='Beta Phylogenetic Meta Passthrough',
-    description="Computes a distance matrix for all pairs of samples in a "
-                "feature table using the unifrac implementation of the "
-                "selected beta diversity metric.",
+    description="Computes a distance matrix for all pairs of samples in the "
+                "set of feature table and phylogeny pairs, using the unifrac "
+                "implementation of the selected beta diversity metric.",
     citations=[
         citations['lozupone2005unifrac'],
         citations['lozupone2007unifrac'],
@@ -400,6 +400,7 @@ plugin.methods.register_function(
         citations['lozupone2011unifrac'],
         citations['mcdonald2018unifrac'],
         citations['chang2011variance'],
-        citations['chen2012genUnifrac']
+        citations['chen2012genUnifrac'],
+        citations['lozupone2008metaunifrac']
     ]
 )

--- a/q2_diversity_lib/tests/test_beta.py
+++ b/q2_diversity_lib/tests/test_beta.py
@@ -67,20 +67,10 @@ class SmokeTests(TestPluginBase):
                         phylogeny=self.valid_tree_as_NewickFormat)
 
     def test_phylogenetic_measures_passed_empty_tree(self):
-        # HACK: different regular expressions are used here for unweighted and
-        # all other unifracs, because tree/table validation is not being
-        # applied to the other unifracs. Once unifrac PR #106 is merged, this
-        # change will need to be reverted.
-        for measure in phylogenetic_measures:
-            if (measure.__name__ == 'unweighted_unifrac'):
-                with self.assertRaisesRegex(ValueError, "newick"):
-                    measure(table=self.valid_table_as_BIOMV210Format,
-                            phylogeny=self.empty_tree_as_NewickFormat)
-            else:
-                with self.assertRaisesRegex(
-                        ValueError, 'table.*not.*completely represented'):
-                    measure(table=self.valid_table_as_BIOMV210Format,
-                            phylogeny=self.empty_tree_as_NewickFormat)
+       for measure in phylogenetic_measures:
+            with self.assertRaisesRegex(ValueError, "newick"):
+                measure(table=self.valid_table_as_BIOMV210Format,
+                        phylogeny=self.empty_tree_as_NewickFormat)
 
     def test_phylogenetic_measures_passed_root_only_tree(self):
         for measure in phylogenetic_measures:

--- a/q2_diversity_lib/tests/test_beta.py
+++ b/q2_diversity_lib/tests/test_beta.py
@@ -67,7 +67,7 @@ class SmokeTests(TestPluginBase):
                         phylogeny=self.valid_tree_as_NewickFormat)
 
     def test_phylogenetic_measures_passed_empty_tree(self):
-       for measure in phylogenetic_measures:
+        for measure in phylogenetic_measures:
             with self.assertRaisesRegex(ValueError, "newick"):
                 measure(table=self.valid_table_as_BIOMV210Format,
                         phylogeny=self.empty_tree_as_NewickFormat)

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -35,6 +35,13 @@ class DisallowEmptyTablesTests(TestPluginBase):
         not_a_table_fp = self.get_data_path('crawford.nwk')
         self.invalid_view_type = NewickFormat(not_a_table_fp, mode='r')
 
+        self.valid_table_list = [self.valid_table_as_BIOMV210Format,
+                                 self.valid_table_as_BIOMV210Format]
+        self.invalid_table_list = [self.valid_table_as_BIOMV210Format,
+                                   self.invalid_view_type]
+        self.has_empty_table_list = [self.empty_table_as_BIOMV210Format,
+                                     self.valid_table_as_BIOMV210Format]
+
         @_disallow_empty_tables
         def f1(table: biom.Table):
             pass
@@ -49,15 +56,29 @@ class DisallowEmptyTablesTests(TestPluginBase):
         with self.assertRaisesRegex(ValueError, "table.*is empty"):
             self.function_with_table_param(self.empty_table_as_BIOMV210Format)
 
+    def test_pass_empty_table_positionally_list(self):
+        with self.assertRaisesRegex(ValueError, "table.*is empty"):
+            self.function_with_table_param(self.has_empty_table_list)
+
     def test_pass_empty_table_as_kwarg(self):
         with self.assertRaisesRegex(ValueError, "table.*is empty"):
             self.function_with_table_param(
                 table=self.empty_table_as_BIOMV210Format)
 
+    def test_pass_empty_table_as_kwarg_list(self):
+        with self.assertRaisesRegex(ValueError, "table.*is empty"):
+            self.function_with_table_param(
+                table=self.has_empty_table_list)
+
     def test_decorated_lambda_with_table_param(self):
         with self.assertRaisesRegex(ValueError, "table.*is empty"):
             decorated_lambda = _disallow_empty_tables(lambda table: None)
             decorated_lambda(self.empty_table_as_BIOMV210Format)
+
+    def test_decorated_lambda_with_table_param_list(self):
+        with self.assertRaisesRegex(ValueError, "table.*is empty"):
+            decorated_lambda = _disallow_empty_tables(lambda table: None)
+            decorated_lambda(self.has_empty_table_list)
 
     def test_wrapped_function_has_no_table_param(self):
         with self.assertRaisesRegex(TypeError, "no parameter.*table"):
@@ -67,6 +88,11 @@ class DisallowEmptyTablesTests(TestPluginBase):
         with self.assertRaisesRegex(
                     ValueError, "Invalid view type.*Newick"):
             self.function_with_table_param(table=self.invalid_view_type)
+
+    def test_passed_invalid_view_type_list(self):
+        with self.assertRaisesRegex(
+                    ValueError, "Invalid view type.*Newick"):
+            self.function_with_table_param(table=self.invalid_table_list)
 
 
 class ValidateRequestedCPUsTests(TestPluginBase):


### PR DESCRIPTION
This is a work in progress pull request that exposes `unifrac.meta`. Would it be possible to get a very quick comment on the approach to handling the passthrough? I wanted to make sure this approach was reasonable before getting the rest of the bits finalized. 

The TODO items that I'm aware of are:

- [x] adjust plugin_setup text to better reflect the method (currently effectively a copy/paste of `beta_phylogenetic`)
- [x] add support for `meta` specific arguments
- [x] add support for checking empty tables

@ebolyen and @thermokarst, per the discussion on handling paired inputs on Slack, I'd be happy to revise this to reflect the `:` syntax but also wanted to get something tentatively in while that discussion solidifies. I'd also be happy to submit a PR to `q2cli` to support the `:` syntax if that is considered a blocker for this PR, although I may need some guidance there as (at the moment) am not very familiar with that codebase.