### PR TITLE
Alpha diversity as sparse or on smaller dense tables

### DIFF
--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -17,7 +17,8 @@ from q2_types.feature_table import BIOMV210Format
 
 
 def _drop_undefined_samples(table, minimum_nonzero_elements):
-    f = lambda v, i, m: (v > 0).sum() >= minimum_nonzero_elements
+    def f(v, i, m):
+        return (v > 0).sum() >= minimum_nonzero_elements
     return table.filter(f, inplace=False).remove_empty()
 
 

--- a/q2_diversity_lib/_util.py
+++ b/q2_diversity_lib/_util.py
@@ -19,10 +19,10 @@ from q2_types.feature_table import BIOMV210Format
 def _drop_undefined_samples(table, minimum_nonzero_elements):
     def f(v, i, m):
         return (v > 0).sum() >= minimum_nonzero_elements
-    return table.filter(f, inplace=False).remove_empty()
+    return table.filter(f, inplace=False)
 
 
-def _partition(table, block_size):
+def _partition(table, block_size=100):
     number_of_splits = max(1, np.ceil(len(table.ids()) / block_size))
     splits = np.array_split(table.ids(), number_of_splits)
     split_map = {}
@@ -34,7 +34,6 @@ def _partition(table, block_size):
         return split_map[i]
 
     for _, block in table.partition(part_f):
-        block.remove_empty(inplace=True)
         yield block
 
 

--- a/q2_diversity_lib/alpha.py
+++ b/q2_diversity_lib/alpha.py
@@ -55,12 +55,8 @@ def faith_pd(table: BIOMV210Format, phylogeny: NewickFormat) -> pd.Series:
 @_disallow_empty_tables
 def observed_features(table: biom.Table) -> pd.Series:
     presence_absence_table = table.pa(inplace=False)
-    counts = presence_absence_table.matrix_data.toarray().astype(int).T
-    sample_ids = presence_absence_table.ids(axis='sample')
-    result = skbio.diversity.alpha_diversity(metric='observed_otus',
-                                             counts=counts, ids=sample_ids)
-    result.name = 'observed_features'
-    return result
+    return pd.Series(presence_absence_table.sum('sample'),
+                     index=table.ids(), name='observed_features')
 
 
 @_disallow_empty_tables

--- a/q2_diversity_lib/alpha.py
+++ b/q2_diversity_lib/alpha.py
@@ -55,7 +55,7 @@ def faith_pd(table: BIOMV210Format, phylogeny: NewickFormat) -> pd.Series:
 @_disallow_empty_tables
 def observed_features(table: biom.Table) -> pd.Series:
     presence_absence_table = table.pa(inplace=False)
-    return pd.Series(presence_absence_table.sum('sample'),
+    return pd.Series(presence_absence_table.sum('sample').astype(int),
                      index=table.ids(), name='observed_features')
 
 
@@ -67,11 +67,11 @@ def pielou_evenness(table: biom.Table,
 
     results = []
     for partition in _partition(table):
-        counts = partition.matrix_data.astype(int).toarray().T
+        counts = partition.matrix_data.T.toarray()
         sample_ids = partition.ids(axis='sample')
-        result = skbio.diversity.alpha_diversity(metric='pielou_e',
-                                                 counts=counts,
-                                                 ids=sample_ids)
+        results.append(skbio.diversity.alpha_diversity(metric='pielou_e',
+                                                       counts=counts,
+                                                       ids=sample_ids))
     result = pd.concat(results)
     result.name = 'pielou_evenness'
     return result
@@ -85,11 +85,11 @@ def shannon_entropy(table: biom.Table,
 
     results = []
     for partition in _partition(table):
-        counts = partition.matrix_data.astype(int).toarray().T
+        counts = partition.matrix_data.T.toarray()
         sample_ids = partition.ids(axis='sample')
-        result = skbio.diversity.alpha_diversity(metric='shannon',
-                                                 counts=counts,
-                                                 ids=sample_ids)
+        results.append(skbio.diversity.alpha_diversity(metric='shannon',
+                                                       counts=counts,
+                                                       ids=sample_ids))
     result = pd.concat(results)
     result.name = 'shannon_entropy'
     return result
@@ -99,12 +99,12 @@ def shannon_entropy(table: biom.Table,
 def alpha_passthrough(table: biom.Table, metric: str) -> pd.Series:
     results = []
     for partition in _partition(table):
-        counts = partition.matrix_data.astype(int).toarray().T
+        counts = partition.matrix_data.astype(int).T.toarray()
         sample_ids = partition.ids(axis='sample')
 
-        result = skbio.diversity.alpha_diversity(metric=metric,
-                                                 counts=counts,
-                                                 ids=sample_ids)
-    results = pd.concat(results)
+        results.append(skbio.diversity.alpha_diversity(metric=metric,
+                                                       counts=counts,
+                                                       ids=sample_ids))
+    result = pd.concat(results)
     result.name = metric
     return result

--- a/q2_diversity_lib/tests/test_util.py
+++ b/q2_diversity_lib/tests/test_util.py
@@ -9,6 +9,7 @@
 from unittest import mock
 
 import numpy as np
+import numpy.testing as npt
 import biom
 import psutil
 from qiime2 import Artifact
@@ -16,7 +17,31 @@ from qiime2.plugin.testing import TestPluginBase
 from q2_types.feature_table import BIOMV210Format
 from q2_types.tree import NewickFormat
 
-from .._util import _disallow_empty_tables, _validate_requested_cpus
+from .._util import (_disallow_empty_tables, _validate_requested_cpus,
+                     _partition)
+
+
+class PartitionTests(TestPluginBase):
+    package = 'q2_diversity_lib.tests'
+
+    def test_table_below_batch_size(self):
+        tab = biom.example_table.copy()
+        partitions = list(_partition(tab, block_size=10))
+        self.assertEqual(len(partitions), 1)
+        self.assertEqual(tab, partitions[0])
+
+    def test_table_above_batch_size(self):
+        tab = biom.example_table.copy()
+        partitions = list(_partition(tab, block_size=2))
+        self.assertEqual(len(partitions), 2)
+        npt.assert_equal(partitions[0].ids(), tab.ids()[:2])
+        npt.assert_equal(partitions[1].ids(), tab.ids()[2])
+
+    def test_table_equal_to_batch_size(self):
+        tab = biom.example_table.copy()
+        partitions = list(_partition(tab, block_size=3))
+        self.assertEqual(len(partitions), 1)
+        self.assertEqual(tab, partitions[0])
 
 
 class DisallowEmptyTablesTests(TestPluginBase):


### PR DESCRIPTION
Compute alpha metrics either directly from sparse data, or operate on partitions to minimize memory use on dense conversions. 

This PR is important as, at present, it takes 40GB to compute observed features on a table that contains 0.2GB of nonzero data. 