### PR TITLE
BUG: fixes faith_pd truncating float-like ids

### DIFF
--- a/q2_diversity_lib/alpha.py
+++ b/q2_diversity_lib/alpha.py
@@ -23,6 +23,8 @@ from ._util import (_validate_tables,
                     _validate_requested_cpus,
                     _omp_cmd_wrapper)
 
+from qiime2.plugin.util import transform
+
 from q2_diversity_lib.skbio._methods import (_berger_parker, _brillouin_d,
                                              _simpsons_dominance, _esty_ci,
                                              _goods_coverage, _margalef,
@@ -58,8 +60,17 @@ METRICS = {
 @_validate_requested_cpus
 def faith_pd(table: BIOMV210Format, phylogeny: NewickFormat,
              threads: int = 1) -> AlphaDiversityFormat:
+    # create id mapping
+    # if sample_id are floats b/c faith_pd will truncate
+    table_df = table.view(pd.DataFrame)
+    real_index = table_df.index
+    temp_ids = ['q2..' + str(i) for i in table_df.index]
+    id_mapping = pd.DataFrame(index=temp_ids, data={"real_id": real_index})
+    table_df.index = temp_ids
+    btable = transform(table_df, to_type=BIOMV210Format)
+
     vec = AlphaDiversityFormat()
-    cmd = ['faithpd', '-i', str(table), '-t', str(phylogeny), '-o', str(vec)]
+    cmd = ['faithpd', '-i', str(btable), '-t', str(phylogeny), '-o', str(vec)]
     _omp_cmd_wrapper(threads, cmd)
 
     # this is needed to prevent #SampleID from being retained as the
@@ -67,8 +78,12 @@ def faith_pd(table: BIOMV210Format, phylogeny: NewickFormat,
     # (consistent with the other diversity outputs)
     df = pd.read_csv(str(vec), sep='\t', header=0)
     df.set_index(df.columns[0], inplace=True)
-    df.index.name = None
-    df.to_csv(str(vec), sep='\t', header=True)
+    # set original sample_ids back
+    temp_df = id_mapping.join(df)
+    temp_df.reset_index(drop=True, inplace=True)
+    temp_df.set_index("real_id", inplace=True)
+    temp_df.index.name = None
+    temp_df.to_csv(str(vec), sep='\t', header=True)
 
     return vec
 

--- a/q2_diversity_lib/tests/test_alpha.py
+++ b/q2_diversity_lib/tests/test_alpha.py
@@ -102,6 +102,14 @@ class FaithPDTests(TestPluginBase):
             data = fh.read()
             self.assertNotIn('#SampleID', data)
 
+    def test_float_ids(self):
+        table = self.tbl.view(pd.DataFrame)
+        table.index = ['0.0000', '10.0000', '100.00', '1.000', '1.010']
+        table_art = Artifact.import_data('FeatureTable[Frequency]', table)
+        faith_pd, = self.fn(table=table_art, phylogeny=self.tre)
+        fp_series = faith_pd.view(pd.Series)
+        self.assertTrue(table.index.equals(fp_series.index))
+
 
 class ObservedFeaturesTests(TestPluginBase):
     package = 'q2_diversity_lib.tests'


### PR DESCRIPTION
This PR creates an id mapping before handing data into our faith_pd wrapper and then maps them back to original ids before returning. This prevents float like ids from being truncated 
close #73
