### PR TITLE
IMP: improve efficiency of scipy `pdist`-based beta diversity calculations

### DIFF
--- a/q2_diversity_lib/beta.py
+++ b/q2_diversity_lib/beta.py
@@ -70,7 +70,7 @@ def beta_passthrough(table: biom.Table, metric: str, pseudocount: int = 1,
     def jensen_shannon(x, y, **kwds):
         return jensenshannon(x, y)
 
-    counts = table.matrix_data.toarray().T
+    counts = table.matrix_data.toarray().T.copy()
     sample_ids = table.ids(axis='sample')
     if metric == 'aitchison':
         counts += pseudocount
@@ -170,7 +170,7 @@ def beta_phylogenetic_meta_passthrough(tables: BIOMV210Format,
 @_validate_tables
 @_validate_requested_cpus
 def bray_curtis(table: biom.Table, n_jobs: int = 1) -> skbio.DistanceMatrix:
-    counts = table.matrix_data.toarray().T
+    counts = table.matrix_data.toarray().T.copy()
     sample_ids = table.ids(axis='sample')
     return skbio.diversity.beta_diversity(
         metric='braycurtis',
@@ -185,7 +185,7 @@ def bray_curtis(table: biom.Table, n_jobs: int = 1) -> skbio.DistanceMatrix:
 @_validate_tables
 @_validate_requested_cpus
 def jaccard(table: biom.Table, n_jobs: int = 1) -> skbio.DistanceMatrix:
-    counts = table.matrix_data.toarray().T
+    counts = table.matrix_data.toarray().T.copy()
     sample_ids = table.ids(axis='sample')
     return skbio.diversity.beta_diversity(
         metric='jaccard',


### PR DESCRIPTION
Switch from providing a transpose view of the feature table to a copy where sample vectors use contiguous memory. This optimizes the downstream calculations that operate on sample vectors. 

Update: For the problematic `boots kmer-diversity` run that led me to this, this commit reduces runtime to about 13% of what it was previously (from ~36 hours to ~5 hours). Mantel test on Jaccard distance matrices between the two runs gives rho=0.9997, p<0.001. My notes on profiling are [here](https://gist.github.com/gregcaporaso/87143021f87ef24af872fa46225ee33e). 
