### PR TITLE
ENH: enable setting of log base for shannon calculation

### DIFF
--- a/q2_diversity_lib/alpha.py
+++ b/q2_diversity_lib/alpha.py
@@ -134,7 +134,11 @@ def pielou_evenness(table: biom.Table,
 
 @_validate_tables
 def shannon_entropy(table: biom.Table,
-                    drop_undefined_samples: bool = False) -> pd.Series:
+                    drop_undefined_samples: bool = False,
+                    base: float = 2) -> pd.Series:
+    if base == 'e':
+        base = np.e
+
     if drop_undefined_samples:
         table = table.remove_empty(inplace=False)
 
@@ -143,7 +147,7 @@ def shannon_entropy(table: biom.Table,
         # using in-house metrics temporarily
         # results.append(_skbio_alpha_diversity_from_1d(v, 'shannon'))
         v = np.reshape(v, (1, len(v)))
-        results.extend([_shannon(c)for c in v])
+        results.extend([_shannon(c, base=base)for c in v])
     results = pd.Series(results, index=table.ids(), name='shannon_entropy')
     return results
 

--- a/q2_diversity_lib/examples.py
+++ b/q2_diversity_lib/examples.py
@@ -116,6 +116,21 @@ def shannon_entropy_example(use):
     result.assert_output_type('SampleData[AlphaDiversity]')
 
 
+def shannon_base_e_example(use):
+    ft = use.init_artifact('feature_table', ft1_factory)
+    use.comment("Set the logarithm base to e for the Shannon calculation. ")
+    use.comment("This will result in values that match those produced by ")
+    use.comment("vegan and scikit-bio.")
+
+    result, = use.action(
+        use.UsageAction(plugin_id='diversity_lib',
+                        action_id='shannon_entropy'),
+        use.UsageInputs(table=ft, base='e'),
+        use.UsageOutputNames(vector='shannon_vector')
+    )
+    result.assert_output_type('SampleData[AlphaDiversity]')
+
+
 def shannon_drop_example(use):
     ft = use.init_artifact('feature_table', ft1_factory)
     result, = use.action(

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -141,6 +141,7 @@ plugin.methods.register_function(
     description="Compute Shannon's Entropy for each sample in a "
                 "feature table",
     examples={'basic': examples.shannon_entropy_example,
+              'base_e': examples.shannon_base_e_example,
               'dropping undefined samples': examples.shannon_drop_example},
     citations=[citations['shannon1948communication']]
 )

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -122,14 +122,18 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=alpha.shannon_entropy,
     inputs={'table': FeatureTable[Frequency | RelativeFrequency]},
-    parameters={'drop_undefined_samples': Bool},
+    parameters={'drop_undefined_samples': Bool,
+                'base': Float % Range(0, None, inclusive_start=False) |
+                        Str % Choices('e')},
     outputs=[('vector', SampleData[AlphaDiversity])],
     input_descriptions={'table': "The feature table containing the samples "
                         "for which Shannon's Entropy should be computed."},
     parameter_descriptions={'drop_undefined_samples': "Samples with no "
                             "observed features produce undefined (NaN) values."
                             " If true, these samples are dropped from the "
-                            "output vector."},
+                            "output vector.",
+                            'base': "The logarithm base used in calculations."
+                            },
     output_descriptions={'vector': "Vector containing per-sample values "
                                    "for Shannon's Entropy."},
     name="Shannon's Entropy",

--- a/q2_diversity_lib/plugin_setup.py
+++ b/q2_diversity_lib/plugin_setup.py
@@ -123,8 +123,9 @@ plugin.methods.register_function(
     function=alpha.shannon_entropy,
     inputs={'table': FeatureTable[Frequency | RelativeFrequency]},
     parameters={'drop_undefined_samples': Bool,
-                'base': Float % Range(0, None, inclusive_start=False) |
-                        Str % Choices('e')},
+                'base':
+                    Float % Range(0, None, inclusive_start=False) |
+                    Str % Choices('e')},
     outputs=[('vector', SampleData[AlphaDiversity])],
     input_descriptions={'table': "The feature table containing the samples "
                         "for which Shannon's Entropy should be computed."},

--- a/q2_diversity_lib/tests/test_alpha.py
+++ b/q2_diversity_lib/tests/test_alpha.py
@@ -213,9 +213,21 @@ class ShannonEntropyTests(TestPluginBase):
                  'S5': 1.584962500721156, 'S6': 2},
                 name='shannon_entropy')
 
-    def test_method(self):
+    def test_method_base_2(self):
         actual = shannon_entropy(table=self.input_table)
         pdt.assert_series_equal(actual, self.expected)
+
+    def test_method_base_e(self):
+        # Calculated w skbio 0.6.2 and vegan 2.6-8
+        expected = pd.Series(
+                {'S1': np.NaN, 'S2': 0, 'S3': 0.693147180,
+                 'S4': np.NaN, 'S5': 1.098612288, 'S6': 1.386294361},
+                name='shannon_entropy')
+
+        # passing e as a string here rather than numpy.e, as that's how it'll
+        # come in from the Method
+        actual = shannon_entropy(table=self.input_table, base='e')
+        pdt.assert_series_equal(actual, expected)
 
     def test_accepted_types_have_consistent_behavior(self):
         freq_table = self.input_table


### PR DESCRIPTION
addresses #75

This keeps the default Shannon base unchanged in QIIME 2 (`base=2`), but allows the user to pass whatever base they'd like, including `e` (which matches vegan and scikit-bio). 

Note: I confirmed that the base choice doesn't matter (beyond rounding error) for pielou evenness, so no need to make a change there. 